### PR TITLE
Update readme to use correct plugin name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Add the plugin to serverless.yml:
 
 ```yaml
 plugins:
-  - serverless-iam-roles-per-function
+  - serverless-iamroles
 ```
 
-**Note**: Node 6.10 or higher runtime required.
+**Note**: Node 10 or higher runtime required.
 
 ## Usage
 


### PR DESCRIPTION
While it is intended to replace classical iam-roles-per function, let's match the readme for the plugin
main thing:
1. plugin requirement in yaml should match the published package name
2. default inherit for the plugin is based on the plugin name from index.ts, so it is still ```serverless-iam-roles-per-function```